### PR TITLE
Add Python CI workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,25 @@
+name: Python CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8
+      - name: Lint with flake8
+        run: flake8 .
+      - name: Validate importability
+        run: python -m py_compile $(git ls-files '*.py')


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for linting and basic checks

## Testing
- `flake8 .` *(fails: E501 lines too long and other issues)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68599ba4a2648321a3a2a8c645a15303